### PR TITLE
Install Docker Desktop 2.0.1.0 from edge channel

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ SCRIPT
 
 $script2 = <<SCRIPT2
 iwr -useb https://chocolatey.org/install.ps1 | iex
-choco install -y docker-desktop
+choco install -y docker-desktop -pre
 SCRIPT2
 
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
Use edge channel to get Docker 18.09.1 with the choco `-pre` option.
